### PR TITLE
Remove stale queues

### DIFF
--- a/lib/app/__init__.py
+++ b/lib/app/__init__.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import HTTPException
 
 import app.config
 import app.database
+from app.queue import init_queues, remove_unused_queues
 
 
 flask_app = None
@@ -145,6 +146,8 @@ def init_flask(flask_app, config):
 
     db_engine = app.database.get_engine(dict(config.items('database')))
     redis = app.database.get_redis(dict(config.items('redis')))
+    remove_unused_queues(redis)
+    init_queues(redis)
 
     signer = Signer(config.get('flask', 'SECRET_KEY'))
     sign_fn = lambda s: signer.sign(str(s).encode('utf8')).decode('utf-8')

--- a/lib/app/queue.py
+++ b/lib/app/queue.py
@@ -1,6 +1,6 @@
 ''' Message queues. '''
 
-from rq import Queue
+from rq import Connection, Queue
 
 import app.config
 import worker
@@ -10,6 +10,43 @@ _config = app.config.get_config()
 _redis = app.database.get_redis(dict(_config.items('redis')))
 _redis_worker = dict(_config.items('redis_worker'))
 _scrape_queue = Queue('scrape', connection=_redis)
+_archive_queue = Queue('archive', connection=_redis)
+
+def dummy_job():
+    '''
+    This dummy job is used by init_queues().
+    It must be defined at the module level so that Python RQ can import it;
+    it cannot be an anonymous or nested function.
+    '''
+    pass
+
+
+def init_queues(redis):
+    '''
+    Python RQ creates queues lazily, but we want them created eagerly.
+    This function submits a dummy job to each queue to force Python RQ to
+    create that queue.
+    '''
+    queues = {q for q in globals().values() if type(q) is Queue}
+
+    with Connection(redis):
+        for queue in queues:
+            queue.enqueue(dummy_job)
+
+
+def remove_unused_queues(redis):
+    '''
+    Remove queues in RQ that are not defined in this file.
+    This is useful for removing queues that used to be defined but were later
+    removed.
+    '''
+    queue_names = {q.name for q in globals().values() if type(q) is Queue}
+
+    with Connection(redis):
+        for queue in Queue.all():
+            if queue.name not in queue_names:
+                queue.empty()
+                redis.srem('rq:queues', 'rq:queue:{}'.format(queue.name))
 
 
 def schedule_username(username, group_id=None):


### PR DESCRIPTION
Add two new methods to app.queue:

1) remove_unused_queues: removes any queue not currently exported
   by the app.queue module
2) init_queues: force python RQ to create queues for each queue
   exported by the app.queue module by submitting a dummy job
   to that queue

Invoke these methods (in this order) during application bootstrap
so that each time the application starts, the application's queues
are kept consistent with the app.queue module.